### PR TITLE
:recycle: Update regex to be lazy and handle `!` in text

### DIFF
--- a/custom-span-class.py
+++ b/custom-span-class.py
@@ -34,7 +34,7 @@ from markdown.preprocessors import Preprocessor
 from markdown.inlinepatterns import Pattern
 
 
-CUSTOM_CLS_RE = r'[!]{2}(?P<class>[^!]+)[|\^](?P<text>[^!]+)[!]{2}'
+CUSTOM_CLS_RE = r'[!]{2}(?P<class>.+?)[|\^](?P<text>.+?(?=[!]{2}))(?=(?P<lookahead>[!]{3}))?(?(lookahead)(?P<exclaim>!))[!]{2}'
 
 
 class CustomSpanClassExtension(Extension):
@@ -55,6 +55,9 @@ class CustomSpanClassPattern(Pattern):
 
         cls = matched.group("class")
         text = matched.group("text")
+        exclaim_ending = matched.group("exclaim")
+        if exclaim_ending is not None:
+            text += "!"
 
         elem = markdown.util.etree.Element("span")
         elem.set("class", cls)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup
 setup(
     name='mdx-custom-span-class',
-    version='1.1.3',
+    version='1.1.4',
     author='Konrad Wasowicz',
     author_email='exaroth@gmail.com',
     description='Markdown extension which allows inserting span elements with custom class',


### PR DESCRIPTION
# Description

This PR reverts the regex to use a match all (`.+`) token with the addition of being lazy (`?` - match as little as possible, consuming as needed) instead of greedy (match as much as possible, giving back as needed) which allows for using an `!` in the text.

## Regex Explanation
[!]{2} - match two leading exclamation points
(?P\<class\>.+?)[|\^] - match anything once or more (lazily) until a `|` or `^` is found
(?P\<text\>.+?(?=[!]{2})) - match anything once or more (lazily) until two consecutive `!`s are found 
(?=(?P\<lookahead\>[!]{3}))? - check if there are three consecutive `!`s 
(?(lookahead)(?P\<exclaim\>!)) - if three consecutive `!`s were found match one `!`
[!]{2} - match two trailing exclamation points

## Tested Cases

- multiple spans in a single line 
- using an `!` anywhere in the text
- using an `!` anywhere in the class

**NOTE:** The edge case of an exclamation point at the end of the `text` (i.e. having 3 `!` in a row) required appending an `!` to the `text`

See here for tested cases: https://regex101.com/r/BZnHIO/2

**NOTE:**
Markdown is using the python standard library `re` as its regex library. `re` doesn't allow for conditional expressions unless the condition is a previous capture group - https://docs.python.org/3/library/re.html?highlight=(?(id/name). This forced a conditional matching capture group named "lookahead" which is then used in the conditional expression instead of having the lookahead inline in the conditional.

